### PR TITLE
Fix server being online even if server fails to boot and during shutdown caused by watchdog thread or a crash

### DIFF
--- a/patches/server/0133-Add-generic-file-syncing-between-servers.patch
+++ b/patches/server/0133-Add-generic-file-syncing-between-servers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add generic file syncing between servers
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index e8a37141d9020a760def17978a603ab112abb205..310cbf7d2d9d09440b2b26615a82adb2f4da1ca6 100644
+index 536c2851cfeea7a7e8494b57b36e965a2e478e19..ddaac25a3274a5973260cc37bb001af6afb08ac2 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -57,6 +57,8 @@ dependencies {
@@ -18,7 +18,7 @@ index e8a37141d9020a760def17978a603ab112abb205..310cbf7d2d9d09440b2b26615a82adb2
      implementation("com.github.technove:Flare:2c4a2114a0") // Airplane - flare
  
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 4201e0debe2e4918dd926dba325717a6bd35ed2b..af6a2eaf51b34a326c4cbec4b8e0fb84fd4dc172 100644
+index 4201e0debe2e4918dd926dba325717a6bd35ed2b..1095e0549de22085cd1385320dfc1da1d1c2224c 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -68,6 +68,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -38,8 +38,46 @@ index 4201e0debe2e4918dd926dba325717a6bd35ed2b..af6a2eaf51b34a326c4cbec4b8e0fb84
  
              Bootstrap.bootStrap();
              Bootstrap.validate();
+@@ -160,6 +163,7 @@ public class Main {
+             // Spigot End
+             if (!eula.hasAgreedToEULA() && !eulaAgreed) { // Spigot
+                 Main.LOGGER.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
++                System.exit(0); // MultiPaper
+                 return;
+             }
+ 
+@@ -184,11 +188,13 @@ public class Main {
+             if (worldinfo != null) {
+                 if (worldinfo.requiresManualConversion()) {
+                     Main.LOGGER.info("This world must be opened in an older version (like 1.6.4) to be safely converted");
++                    System.exit(0); // MultiPaper
+                     return;
+                 }
+ 
+                 if (!worldinfo.isCompatible()) {
+                     Main.LOGGER.info("This world was created by an incompatible version.");
++                    System.exit(0); // MultiPaper
+                     return;
+                 }
+             }
+@@ -264,6 +270,7 @@ public class Main {
+                 }).get();
+             } catch (Exception exception) {
+                 Main.LOGGER.warn("Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode", exception);
++                System.exit(0); // MultiPaper
+                 return;
+             }
+ 
+@@ -319,6 +326,7 @@ public class Main {
+             */ // CraftBukkit end
+         } catch (Exception exception1) {
+             Main.LOGGER.error(LogUtils.FATAL_MARKER, "Failed to start the minecraft server", exception1);
++            System.exit(0); // MultiPaper
+         }
+ 
+     }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b256de7e1ed206458568cf84c59bd431eaa29a7b..d6e2843688a7748ffd29390a7331e1b6abb11ad5 100644
+index 6e6f9fd95925b0b73bb576cede1cf5e16b44afd8..e4dfd13f3ea66bc836b36b6840e47e96cf574aa3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -183,6 +183,7 @@ import org.bukkit.event.server.ServerLoadEvent;

--- a/patches/server/0182-make-ensure-know-that-server-had-abnormal-exit-check.patch
+++ b/patches/server/0182-make-ensure-know-that-server-had-abnormal-exit-check.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@glomc.net>
+Date: Tue, 22 Nov 2022 12:19:26 +0400
+Subject: [PATCH] make ensure know that server had abnormal exit + check if
+ current thread equals shutdown thread in mc server class
+
+
+diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
+index e9f0ddf1a34bf3b0d868b53e4439d9d9851ad4d6..55ecc8bac1c12fd8e19a7758d2a1705cef972dcf 100644
+--- a/src/main/java/net/minecraft/server/MCUtil.java
++++ b/src/main/java/net/minecraft/server/MCUtil.java
+@@ -355,6 +355,11 @@ public final class MCUtil {
+      */
+     public static <T> T ensureMain(String reason, Supplier<T> run) {
+         if (!isMainThread()) {
++            // MultiPaper Start - must check if server had abnormal exit + current thread is shutdown thread.
++            if (Thread.currentThread() == MinecraftServer.getServer().shutdownThread && MinecraftServer.getServer().abnormalExit) {
++                return run.get();
++            }
++            // MultiPaper end
+             if (reason != null) {
+                 new IllegalStateException("Asynchronous " + reason + "! Blocking thread until it returns ").printStackTrace();
+             }


### PR DESCRIPTION
- [x] should shutdown during early server start, like eula is false etc.  
- [x] Normal server crash functions normally `like exception in server tick loop` etc *wasn't broken before but good to include it*
- [x] Fix shutdown process hang if server get killed by WatchDog

note: after fixed this bug with hang, there good? behavior that if watchdog killed the server while master is offline it will wait for master to be online then saves everything then exit.  
for example this logs:
```
[12:43:00 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:00 INFO]: Stopping main thread (Ignore any thread death message you see! - DO NOT REPORT THREAD DEATH TO PAPER)
[12:43:00 ERROR]: Main thread terminated by WatchDog due to hard crash
java.lang.ThreadDeath: null
	at java.lang.Thread.stop(Thread.java:942) ~[?:?]
	at net.minecraft.server.MinecraftServer.stopServer(MinecraftServer.java:924) ~[main/:?]
	at net.minecraft.server.dedicated.DedicatedServer.stopServer(DedicatedServer.java:790) ~[main/:?]
	at net.minecraft.server.MinecraftServer.close(MinecraftServer.java:896) ~[main/:?]
	at org.spigotmc.WatchdogThread.run(WatchdogThread.java:233) ~[main/:?]
[12:43:00 INFO]: Stopping server
[12:43:00 INFO]: Saving players
[12:43:01 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:01 INFO]: Saving worlds
[12:43:02 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:03 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:04 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:05 INFO]: [MultiPaperConnection] Connecting to localhost:35353...
[12:43:05 INFO]: [MultiPaperConnection] Connected to localhost/127.0.0.1:35353
[12:43:05 INFO]: Saving chunks for level 'ServerLevel[world]'/minecraft:overworld
[12:43:05 INFO]: Saving chunks for level 'ServerLevel[world_nether]'/minecraft:the_nether
[12:43:05 INFO]: Saving chunks for level 'ServerLevel[world_the_end]'/minecraft:the_end
[12:43:05 INFO]: ThreadedAnvilChunkStorage (world): All chunks are saved
[12:43:05 INFO]: ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
[12:43:05 INFO]: ThreadedAnvilChunkStorage (DIM1): All chunks are saved
[12:43:05 INFO]: ThreadedAnvilChunkStorage: All dimensions are saved
[12:43:05 INFO]: Flushing Chunk IO
[12:43:05 INFO]: Closing MultiPaper File Syncer
[12:43:05 INFO]: Closing Thread Pool
2022-11-22 12:43:05,087 Log4j2-AsyncAppenderEventDispatcher-1-Async WARN Advanced terminal features are not available in this environment
[12:43:05 INFO]: Closing Server
```

closes #290 
closes #276 