### PR TITLE
[Fix #303 again] fix: PersistentDataContainer share on block update

### DIFF
--- a/patches/server/0183-fix-PersistentDataContainer-sanitize.patch
+++ b/patches/server/0183-fix-PersistentDataContainer-sanitize.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Robert Nisipeanu <github@nisipeanu.com>
+Date: Mon, 2 Jan 2023 23:10:48 +0200
+Subject: [PATCH] fix: PersistentDataContainer sanitize
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
+index 257c3df5aa6734ab36053438e328f816ce3acdff..768d168658e5acd06e1febba5e20ed9b10974333 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
++++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
+@@ -464,7 +464,7 @@ public class ChunkHolder {
+                 this.broadcast(packet, false);
+             }
+ 
+-            if(!broadcastingToPlayersOnly) MultiPaperChunkHandler.onBlockUpdate(this, ClientboundBlockEntityDataPacket.create(tileentity, BlockEntity::saveWithFullMetadata)); // MultiPaper - sync the full block with external servers
++            if(!broadcastingToPlayersOnly) MultiPaperChunkHandler.onBlockUpdate(this, ClientboundBlockEntityDataPacket.create(tileentity, BlockEntity::saveWithFullMetadata, false)); // MultiPaper - sync the full block with external servers
+         }
+ 
+     }


### PR DESCRIPTION
Somehow I forgot to commit one file in PR #304 so issue #303 was still present