### PR TITLE
Event When Player Join Leave

### DIFF
--- a/patches/api/0009-Event-When-Player-Join-Leave.patch
+++ b/patches/api/0009-Event-When-Player-Join-Leave.patch
@@ -10,13 +10,12 @@ Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allo
 
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4f5ce84ed3d9633a145dd035dd4fb6fd348dcaf0
+index 0000000000000000000000000000000000000000..ddef7f472de8dc1628471187030449be4bd5454a
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,48 @@
 +package puregero.multipaper.event.player;
 +
-+import org.bukkit.Bukkit;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.jetbrains.annotations.NotNull;
@@ -34,7 +33,7 @@ index 0000000000000000000000000000000000000000..4f5ce84ed3d9633a145dd035dd4fb6fd
 +
 +
 +    public PlayerJoinExternalServerEvent(UUID playerUniqueId, String playerName) {
-+        super(!Bukkit.isPrimaryThread());
++        super(false);
 +        this.playerUniqueId = playerUniqueId;
 +        this.playerName = playerName;
 +    }
@@ -65,13 +64,12 @@ index 0000000000000000000000000000000000000000..4f5ce84ed3d9633a145dd035dd4fb6fd
 +}
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..33a39d9d8740ce206b552c60e065c20b3f650491
+index 0000000000000000000000000000000000000000..9359145d961f0bddf3037e77a73d9f683e8fdcb3
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,49 @@
 +package puregero.multipaper.event.player;
 +
-+import org.bukkit.Bukkit;
 +import org.bukkit.event.Event;
 +import org.bukkit.event.HandlerList;
 +import org.jetbrains.annotations.NotNull;
@@ -90,7 +88,7 @@ index 0000000000000000000000000000000000000000..33a39d9d8740ce206b552c60e065c20b
 +
 +
 +    public PlayerLeaveExternalServerEvent(UUID playerUniqueId, String playerName) {
-+        super(!Bukkit.isPrimaryThread());
++        super(false);
 +        this.playerUniqueId = playerUniqueId;
 +        this.playerName = playerName;
 +    }

--- a/patches/api/0009-Event-When-Player-Join-Leave.patch
+++ b/patches/api/0009-Event-When-Player-Join-Leave.patch
@@ -10,7 +10,7 @@ Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allo
 
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8a64f1edf3c0e95b16b44383892c4dd74f99a394
+index 0000000000000000000000000000000000000000..ae5f518eca89fd253de18cd448d45e3f1abf1678
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
 @@ -0,0 +1,59 @@
@@ -60,7 +60,7 @@ index 0000000000000000000000000000000000000000..8a64f1edf3c0e95b16b44383892c4dd7
 +     * @return the bungeecord name of this server
 +     */
 +    public String getLocalServerName() {
-+        return localServerName;
++        return this.localServerName;
 +    }
 +
 +    @Override
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..8a64f1edf3c0e95b16b44383892c4dd7
 +}
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..12ee8f6f6534465b8daca33e9b94aa09cf086704
+index 0000000000000000000000000000000000000000..3c08202ea439350209ee8faf2cd04990199f0026
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
 @@ -0,0 +1,60 @@
@@ -126,7 +126,7 @@ index 0000000000000000000000000000000000000000..12ee8f6f6534465b8daca33e9b94aa09
 +     * @return the bungeecord name of this server
 +     */
 +    public String getLocalServerName() {
-+        return localServerName;
++        return this.localServerName;
 +    }
 +
 +    @Override

--- a/patches/api/0009-Event-When-Player-Join-Leave.patch
+++ b/patches/api/0009-Event-When-Player-Join-Leave.patch
@@ -10,10 +10,10 @@ Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allo
 
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ddef7f472de8dc1628471187030449be4bd5454a
+index 0000000000000000000000000000000000000000..8a64f1edf3c0e95b16b44383892c4dd74f99a394
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,59 @@
 +package puregero.multipaper.event.player;
 +
 +import org.bukkit.event.Event;
@@ -30,12 +30,14 @@ index 0000000000000000000000000000000000000000..ddef7f472de8dc1628471187030449be
 +    private static final HandlerList handlers = new HandlerList();
 +    private final UUID playerUniqueId;
 +    private final String playerName;
++    private final String localServerName;
 +
 +
-+    public PlayerJoinExternalServerEvent(UUID playerUniqueId, String playerName) {
++    public PlayerJoinExternalServerEvent(UUID playerUniqueId, String playerName, String localeServerName) {
 +        super(false);
 +        this.playerUniqueId = playerUniqueId;
 +        this.playerName = playerName;
++        this.localServerName = localeServerName;
 +    }
 +
 +    /**
@@ -52,6 +54,15 @@ index 0000000000000000000000000000000000000000..ddef7f472de8dc1628471187030449be
 +        return this.playerUniqueId;
 +    }
 +
++    /**
++     * Get the bungeecord name of this server.
++     *
++     * @return the bungeecord name of this server
++     */
++    public String getLocalServerName() {
++        return localServerName;
++    }
++
 +    @Override
 +    public @NotNull HandlerList getHandlers() {
 +        return handlers;
@@ -64,10 +75,10 @@ index 0000000000000000000000000000000000000000..ddef7f472de8dc1628471187030449be
 +}
 diff --git a/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9359145d961f0bddf3037e77a73d9f683e8fdcb3
+index 0000000000000000000000000000000000000000..12ee8f6f6534465b8daca33e9b94aa09cf086704
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,60 @@
 +package puregero.multipaper.event.player;
 +
 +import org.bukkit.event.Event;
@@ -85,12 +96,14 @@ index 0000000000000000000000000000000000000000..9359145d961f0bddf3037e77a73d9f68
 +    private static final HandlerList handlers = new HandlerList();
 +    private final UUID playerUniqueId;
 +    private final String playerName;
++    private final String localServerName;
 +
 +
-+    public PlayerLeaveExternalServerEvent(UUID playerUniqueId, String playerName) {
++    public PlayerLeaveExternalServerEvent(UUID playerUniqueId, String playerName, String localServerName) {
 +        super(false);
 +        this.playerUniqueId = playerUniqueId;
 +        this.playerName = playerName;
++        this.localServerName = localServerName;
 +    }
 +
 +    /**
@@ -105,6 +118,15 @@ index 0000000000000000000000000000000000000000..9359145d961f0bddf3037e77a73d9f68
 +     */
 +    public UUID getPlayerUniqueId() {
 +        return this.playerUniqueId;
++    }
++
++    /**
++     * Get the bungeecord name of this server.
++     *
++     * @return the bungeecord name of this server
++     */
++    public String getLocalServerName() {
++        return localServerName;
 +    }
 +
 +    @Override

--- a/patches/api/0009-Event-When-Player-Join-Leave.patch
+++ b/patches/api/0009-Event-When-Player-Join-Leave.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DoctaEnkoda <bierquejason@gmail.com>
+Date: Tue, 3 Jan 2023 03:32:37 +0100
+Subject: [PATCH] Event When Player Join Leave
+
+Add PlayerLeaveExternalServerEvent when Player Leave an External Server
+Add PlayerJoinExternalServerEvent when Player Join an External Server
+
+Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allows to know when a player leaves a server on another instance.
+
+diff --git a/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4f5ce84ed3d9633a145dd035dd4fb6fd348dcaf0
+--- /dev/null
++++ b/src/main/java/puregero/multipaper/event/player/PlayerJoinExternalServerEvent.java
+@@ -0,0 +1,49 @@
++package puregero.multipaper.event.player;
++
++import org.bukkit.Bukkit;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.UUID;
++
++/**
++ * Called when a player joins an external MultiPaper instance.
++ */
++public class PlayerJoinExternalServerEvent extends Event {
++
++    private static final HandlerList handlers = new HandlerList();
++    private final UUID playerUniqueId;
++    private final String playerName;
++
++
++    public PlayerJoinExternalServerEvent(UUID playerUniqueId, String playerName) {
++        super(!Bukkit.isPrimaryThread());
++        this.playerUniqueId = playerUniqueId;
++        this.playerName = playerName;
++    }
++
++    /**
++     * Returns the name of this player
++     */
++    public String getPlayerName() {
++        return this.playerName;
++    }
++
++    /**
++     * Returns a unique and persistent id for this entity
++     */
++    public UUID getPlayerUniqueId() {
++        return this.playerUniqueId;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..33a39d9d8740ce206b552c60e065c20b3f650491
+--- /dev/null
++++ b/src/main/java/puregero/multipaper/event/player/PlayerLeaveExternalServerEvent.java
+@@ -0,0 +1,50 @@
++package puregero.multipaper.event.player;
++
++import org.bukkit.Bukkit;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.UUID;
++
++/**
++ * Called when a player leave an external MultiPaper instance.
++ */
++public class PlayerLeaveExternalServerEvent extends Event {
++
++
++    private static final HandlerList handlers = new HandlerList();
++    private final UUID playerUniqueId;
++    private final String playerName;
++
++
++    public PlayerLeaveExternalServerEvent(UUID playerUniqueId, String playerName) {
++        super(!Bukkit.isPrimaryThread());
++        this.playerUniqueId = playerUniqueId;
++        this.playerName = playerName;
++    }
++
++    /**
++     * Returns the name of this player
++     */
++    public String getPlayerName() {
++        return this.playerName;
++    }
++
++    /**
++     * Returns a unique and persistent id for this entity
++     */
++    public UUID getPlayerUniqueId() {
++        return this.playerUniqueId;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/0183-Event-When-Player-Join-Leave.patch
+++ b/patches/server/0183-Event-When-Player-Join-Leave.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DoctaEnkoda <bierquejason@gmail.com>
+Date: Tue, 3 Jan 2023 03:35:42 +0100
+Subject: [PATCH] Event When Player Join Leave
+
+Add PlayerLeaveExternalServerEvent when Player Leave an External Server
+Add PlayerJoinExternalServerEvent when Player Join an External Server
+
+Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allows to know when a player leaves a server on another instance.
+
+diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
+index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..2bc25f8fe667f4f90fb51673680ea48d19ddb98e 100644
+--- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
++++ b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
+@@ -14,8 +14,10 @@ import net.minecraft.world.level.GameType;
+ import net.minecraft.world.level.chunk.LevelChunk;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
++import org.bukkit.Bukkit;
+ import org.bukkit.event.player.PlayerKickEvent;
+ import puregero.multipaper.*;
++import puregero.multipaper.event.player.PlayerJoinExternalServerEvent;
+ 
+ import javax.annotation.Nullable;
+ import java.net.InetAddress;
+@@ -144,6 +146,8 @@ public class PlayerCreatePacket extends ExternalServerPacket {
+     @Override
+     public void handle(ExternalServerConnection connection) {
+         LOGGER.info("Adding player " + gameProfile.getName() + " (" + gameProfile.getId() + ")");
++        PlayerJoinExternalServerEvent playerJoinExternalServerEvent = new PlayerJoinExternalServerEvent(gameProfile.getId(), gameProfile.getName());
++        Bukkit.getPluginManager().callEvent(playerJoinExternalServerEvent);
+         MultiPaper.runSync(() -> {
+             ServerPlayer existingPlayer = MinecraftServer.getServer().getPlayerList().getPlayer(gameProfile.getId());
+             if (existingPlayer != null) {
+diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
+index d5853995ed4774799475e5f1c156d5814e524c9d..d0c5767d18732a8c658148180762c76689c15018 100644
+--- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
++++ b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
+@@ -6,9 +6,11 @@ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.server.level.ServerPlayer;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
++import org.bukkit.Bukkit;
+ import org.bukkit.event.player.PlayerKickEvent;
+ import puregero.multipaper.ExternalServerConnection;
+ import puregero.multipaper.MultiPaper;
++import puregero.multipaper.event.player.PlayerLeaveExternalServerEvent;
+ 
+ import java.util.UUID;
+ 
+@@ -44,6 +46,8 @@ public class PlayerRemovePacket extends ExternalServerPacket {
+             }
+ 
+             player.connection.disconnect(EXTERNAL_DISCONNECT_COMPONENT, PlayerKickEvent.Cause.TIMEOUT);
++            PlayerLeaveExternalServerEvent playerLeaveExternalServerEvent = new PlayerLeaveExternalServerEvent(player.getGameProfile().getId(), player.getGameProfile().getName());
++            Bukkit.getPluginManager().callEvent(playerLeaveExternalServerEvent);
+         });
+     }
+ }

--- a/patches/server/0183-Event-When-Player-Join-Leave.patch
+++ b/patches/server/0183-Event-When-Player-Join-Leave.patch
@@ -9,34 +9,35 @@ Add PlayerJoinExternalServerEvent when Player Join an External Server
 Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allows to know when a player leaves a server on another instance.
 
 diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
-index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..7c353a98088912d2a5eb2651422847d4d24e017d 100644
+index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..9c0936cb15fc32a14904206b8a119dc4bf718e50 100644
 --- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
 +++ b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
-@@ -14,8 +14,10 @@ import net.minecraft.world.level.GameType;
+@@ -14,8 +14,11 @@ import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.chunk.LevelChunk;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
 +import org.bukkit.Bukkit;
  import org.bukkit.event.player.PlayerKickEvent;
  import puregero.multipaper.*;
++import puregero.multipaper.config.MultiPaperConfiguration;
 +import puregero.multipaper.event.player.PlayerJoinExternalServerEvent;
  
  import javax.annotation.Nullable;
  import java.net.InetAddress;
-@@ -161,6 +163,8 @@ public class PlayerCreatePacket extends ExternalServerPacket {
+@@ -161,6 +164,8 @@ public class PlayerCreatePacket extends ExternalServerPacket {
              ExternalPlayer player = ExternalPlayer.create(connection, gameProfile, world, x, y, z, yaw, pitch, gamemode, address, profilePublicKey, advancements, stats, entityId);
              player.getBukkitEntity().data = data;
              player.getBukkitEntity().persistentData = persistentData;
-+            PlayerJoinExternalServerEvent playerJoinExternalServerEvent = new PlayerJoinExternalServerEvent(gameProfile.getId(), gameProfile.getName());
++            PlayerJoinExternalServerEvent playerJoinExternalServerEvent = new PlayerJoinExternalServerEvent(gameProfile.getId(), gameProfile.getName(), MultiPaperConfiguration.get().masterConnection.myName);
 +            Bukkit.getPluginManager().callEvent(playerJoinExternalServerEvent);
          });
      }
  
 diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
-index d5853995ed4774799475e5f1c156d5814e524c9d..d0c5767d18732a8c658148180762c76689c15018 100644
+index d5853995ed4774799475e5f1c156d5814e524c9d..28b1190e304b937468be426dcba17ef4ec727e36 100644
 --- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
 +++ b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
-@@ -6,9 +6,11 @@ import net.minecraft.server.MinecraftServer;
+@@ -6,9 +6,12 @@ import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerPlayer;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -44,15 +45,16 @@ index d5853995ed4774799475e5f1c156d5814e524c9d..d0c5767d18732a8c658148180762c766
  import org.bukkit.event.player.PlayerKickEvent;
  import puregero.multipaper.ExternalServerConnection;
  import puregero.multipaper.MultiPaper;
++import puregero.multipaper.config.MultiPaperConfiguration;
 +import puregero.multipaper.event.player.PlayerLeaveExternalServerEvent;
  
  import java.util.UUID;
  
-@@ -44,6 +46,8 @@ public class PlayerRemovePacket extends ExternalServerPacket {
+@@ -44,6 +47,8 @@ public class PlayerRemovePacket extends ExternalServerPacket {
              }
  
              player.connection.disconnect(EXTERNAL_DISCONNECT_COMPONENT, PlayerKickEvent.Cause.TIMEOUT);
-+            PlayerLeaveExternalServerEvent playerLeaveExternalServerEvent = new PlayerLeaveExternalServerEvent(player.getGameProfile().getId(), player.getGameProfile().getName());
++            PlayerLeaveExternalServerEvent playerLeaveExternalServerEvent = new PlayerLeaveExternalServerEvent(player.getGameProfile().getId(), player.getGameProfile().getName(), MultiPaperConfiguration.get().masterConnection.myName);
 +            Bukkit.getPluginManager().callEvent(playerLeaveExternalServerEvent);
          });
      }

--- a/patches/server/0183-Event-When-Player-Join-Leave.patch
+++ b/patches/server/0183-Event-When-Player-Join-Leave.patch
@@ -9,7 +9,7 @@ Add PlayerJoinExternalServerEvent when Player Join an External Server
 Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allows to know when a player leaves a server on another instance.
 
 diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
-index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..2bc25f8fe667f4f90fb51673680ea48d19ddb98e 100644
+index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..7c353a98088912d2a5eb2651422847d4d24e017d 100644
 --- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
 +++ b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerCreatePacket.java
 @@ -14,8 +14,10 @@ import net.minecraft.world.level.GameType;
@@ -23,15 +23,15 @@ index e4bc6f2a4757905e304dbfe0d9bc669d878d0054..2bc25f8fe667f4f90fb51673680ea48d
  
  import javax.annotation.Nullable;
  import java.net.InetAddress;
-@@ -144,6 +146,8 @@ public class PlayerCreatePacket extends ExternalServerPacket {
-     @Override
-     public void handle(ExternalServerConnection connection) {
-         LOGGER.info("Adding player " + gameProfile.getName() + " (" + gameProfile.getId() + ")");
-+        PlayerJoinExternalServerEvent playerJoinExternalServerEvent = new PlayerJoinExternalServerEvent(gameProfile.getId(), gameProfile.getName());
-+        Bukkit.getPluginManager().callEvent(playerJoinExternalServerEvent);
-         MultiPaper.runSync(() -> {
-             ServerPlayer existingPlayer = MinecraftServer.getServer().getPlayerList().getPlayer(gameProfile.getId());
-             if (existingPlayer != null) {
+@@ -161,6 +163,8 @@ public class PlayerCreatePacket extends ExternalServerPacket {
+             ExternalPlayer player = ExternalPlayer.create(connection, gameProfile, world, x, y, z, yaw, pitch, gamemode, address, profilePublicKey, advancements, stats, entityId);
+             player.getBukkitEntity().data = data;
+             player.getBukkitEntity().persistentData = persistentData;
++            PlayerJoinExternalServerEvent playerJoinExternalServerEvent = new PlayerJoinExternalServerEvent(gameProfile.getId(), gameProfile.getName());
++            Bukkit.getPluginManager().callEvent(playerJoinExternalServerEvent);
+         });
+     }
+ 
 diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java
 index d5853995ed4774799475e5f1c156d5814e524c9d..d0c5767d18732a8c658148180762c76689c15018 100644
 --- a/src/main/java/puregero/multipaper/externalserverprotocol/PlayerRemovePacket.java


### PR DESCRIPTION
- Add PlayerLeaveExternalServerEvent when Player Leave an External Server 
- Add PlayerJoinExternalServerEvent when Player Join an External Server

Beware, this does not replace PlayerJoinEvent and PlayerQuitEvent but still allows to know when a player leaves a server on another instance.