### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -1,0 +1,73 @@
+name: Behavior Bug or Plugin Incompatibility
+description: Report issues with plugin incompatbility or other behavior related issues.
+labels: [ ]
+body:
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: What you expected to see.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Observed/Actual behavior
+      description: What you actually saw.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps/models to reproduce
+      description: This may include a build schematic, a video, or detailed instructions to help reconstruct the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: MultiPaper version
+      description: |
+        Run `/version` on your server and **paste** the full, unmodified output here.
+        "latest" is *not* a version; we require the output of `/version` so we can adequately track down the issue.
+        Additionally, do NOT provide a screenshot, you MUST paste the entire output.
+        <details>
+        <summary>Example</summary>
+
+        ```
+        > version
+        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
+        [20:34:42 INFO]: Checking version, please wait...
+        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: You are running the latest version
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: |
+        Please include other helpful information below.
+        The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of MultiPaper from [our downloads page](https://multipaper.io/download.html).
+        2. You searched for and ensured there isn't already an open issue regarding this.
+        3. Your version of Minecraft is supported by MultiPaper.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: MultiPaper Discord
+    url: https://discord.gg/qaj2g3rjt2
+    about: If you are having issues with timings or have other minor issues, come ask us on our Discord server!
+  #- name: Dupe / exploits Report
+  #  url: https://discord.gg/qaj2g3rjt2
+  #  about: |
+  #    Due to GitHub not currently allowing private issues, exploit / dupes reports are currently handled via our Discord.
+  #    To report an exploit, see the #paper-exploit-report channel.

--- a/.github/ISSUE_TEMPLATE/disclaimer.txt
+++ b/.github/ISSUE_TEMPLATE/disclaimer.txt
@@ -1,0 +1,2 @@
+Some of issues templates are modified version of PaperMC's issue templates
+which can be found here: https://github.com/PaperMC/Paper/tree/master/.github/ISSUE_TEMPLATE

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,44 @@
+name: Feature Request
+description: Suggest an idea for MultiPaper
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filling out a feature request for MultiPaper! Please be as detailed as possible so that we may consider and review the request easier.
+        We ask that you search all the issues to avoid a duplicate feature request. If one exists, please reply if you have anything to add.
+        Before requesting a new feature, please make sure you are using the latest version and that the feature you are requesting is not already in MultiPaper.
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Please give some context for this request. Why do you want it added?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered.
+      description: List any alternatives you might have tried to get the feature you want.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: Add any other context or screenshots about the feature request below.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this feature request, please search our issue tracker to ensure your feature has not
+        already been requested.

--- a/.github/ISSUE_TEMPLATE/performance-problem.yml
+++ b/.github/ISSUE_TEMPLATE/performance-problem.yml
@@ -1,0 +1,84 @@
+name: Performance Problem
+description: Report performance related problems or other areas of concern
+labels: [ ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before creating an issue regarding server performance, please consider reaching out for support in the
+        `#questions` or `#general` channels of [our Discord](https://discord.gg/qaj2g3rjt2)!
+
+  - type: input
+    attributes:
+      label: Timings or Profile link
+      description: We ask that all timings/profiles are a link, not a screenshot. Screenshots inhibit our ability to figure out the real cause of the issue.
+      placeholder: "Example: https://timings.aikar.co/?id=6b48586fbbdd48e585ca0ebb07c59dd0"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Description of issue
+      description: If applicable, please describe your issue.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Server config files
+      description: We need bukkit.yml, spigot.yml, paper-global.yml, paper-world-defaults.yml, multipaper.yml and server.properties. If you use per-world Paper configs, make sure to include them. You can paste it below or use a paste site like https://paste.gg.
+      value: |
+        ```
+        Paste configs or paste.gg link here!
+        ```
+      placeholder: Please don't remove the backticks; it makes your issue a lot harder to read!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: MultiPaper version
+      description: |
+        Run `/version` on your server and **paste** the full, unmodified output here.
+        "latest" is *not* a version; we require the output of `/version` so we can adequately track down the issue.
+        Additionally, do NOT provide a screenshot, you MUST paste the entire output.
+        <details>
+        <summary>Example</summary>
+
+        ```
+        > version
+        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
+        [20:34:42 INFO]: Checking version, please wait...
+        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: You are running the latest version
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: |
+        Please include other helpful links below.
+        The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of MultiPaper from [our downloads page](https://multipaper.io/download.html).
+        2. You searched for and ensured there isn't already an open issue regarding this.
+        3. Your version of Minecraft is supported by MultiPaper.

--- a/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
+++ b/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
@@ -1,0 +1,72 @@
+name: Server crash or Stacktrace
+description: Report server crashes or scary stacktraces
+labels: [ ]
+body:
+  - type: textarea
+    attributes:
+      label: Stack trace
+      description: |
+        We need all of the stack trace! Do not cut off parts of it. Please do not use attachments.
+        If you prefer, you can use a paste site like https://paste.gg.
+      value: |
+        ```
+        paste your stack trace or a paste.gg link here!
+        ```
+      placeholder: Please don't remove the backticks; it makes your issue a lot harder to read!
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actions to reproduce (if known)
+      description: This may include a build schematic, a video, or detailed instructions to help reconstruct the issue. Anything helps!
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: MultiPaper version
+      description: |
+        Run `/version` on your server and **paste** the full, unmodified output here.
+        "latest" is *not* a version; we require the output of `/version` so we can adequately track down the issue.
+        Additionally, do NOT provide a screenshot, you MUST paste the entire output.
+        <details>
+        <summary>Example</summary>
+
+        ```
+        > version
+        [20:34:42 INFO]: This server is running Paper version git-Paper-540 (MC: 1.16.5) (Implementing API version 1.16.5-R0.1-SNAPSHOT)
+        [20:34:42 INFO]: Checking version, please wait...
+        [20:34:42 INFO]: Previous version: git-Paper-538 (MC: 1.16.5)
+        [20:34:42 INFO]: You are running the latest version
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: |
+        Please include other helpful information below, if any.
+        The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of MultiPaper from [our downloads page](https://multipaper.io/download.html).
+        2. Your version of Minecraft is supported by MultiPaper.


### PR DESCRIPTION
issues templates are modified version of PaperMC's issue templates

which can be found here: https://github.com/PaperMC/Paper/tree/master/.github/ISSUE_TEMPLATE