### PR TITLE
Fix entities meta data not being sent to local players if entities are external

### DIFF
--- a/patches/server/0027-Sync-entities.patch
+++ b/patches/server/0027-Sync-entities.patch
@@ -332,7 +332,7 @@ index af730a5adcc86fe1e5ea0b1b67c43299c89ea832..81b88c006a6fb6c451c4a4102ecd26dd
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 194102b40b1c2994fd6dce1873951ead08262c6f..af60b8b1200425b64c787ba72f4e97f091316572 100644
+index 5fe96782fa6d13a6970baf39273e588186219f4f..f1448123b88ef8a926bed8faaabc8129ee290e7a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -102,10 +102,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
@@ -463,7 +463,7 @@ index 98e784fc5ba38979fea3ce188fbcb33ae02d4fcb..60c5f355c0e57f7e13905519655e2f8c
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 094afd5636590608c8ec31c9fec97614dfef60db..4357cf50eee48f8d77588ca9cd16d178ed52b0da 100644
+index b2e4b5c463ceb19356da18e7fc52d20801b674cd..25cc5a1579c9d9fd4745d0f52445ad711be74b4c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -141,6 +141,8 @@ import org.bukkit.event.entity.EntityRegainHealthEvent;
@@ -484,7 +484,7 @@ index 094afd5636590608c8ec31c9fec97614dfef60db..4357cf50eee48f8d77588ca9cd16d178
              return itemStack;
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 7bd4e95fcaf3855a4fe412b5898a97d7992caad3..84e371ce87f068c01b86f450be369e3c8295e2c0 100644
+index 43cc8e8f07adecef21c70954918b8945a7c3ef62..69757ecbf3aa463d7b25902dfe500e0e7a9e643f 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1565,7 +1565,7 @@ public abstract class Mob extends LivingEntity {
@@ -901,10 +901,10 @@ index 8fe8e8a4ba2764f3e91b6c90290bdcbb56402cd7..527fcdebeeca72b18af59dcc48612ac4
  }
 diff --git a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..56b618b56863ad27d923b0fa561bea8de0b20eba
+index 0000000000000000000000000000000000000000..cdf00c101749d1fa76f8854542c3fc99150f2733
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-@@ -0,0 +1,366 @@
+@@ -0,0 +1,372 @@
 +package puregero.multipaper;
 +
 +import com.mojang.datafixers.util.Pair;
@@ -913,6 +913,7 @@ index 0000000000000000000000000000000000000000..56b618b56863ad27d923b0fa561bea8d
 +import net.minecraft.network.protocol.Packet;
 +import net.minecraft.network.protocol.game.*;
 +import net.minecraft.network.syncher.SynchedEntityData;
++import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ChunkMap;
 +import net.minecraft.server.level.ServerLevel;
 +import net.minecraft.server.level.ServerPlayer;
@@ -1116,6 +1117,11 @@ index 0000000000000000000000000000000000000000..56b618b56863ad27d923b0fa561bea8d
 +                        livingEntity.setHealth((Float) item.value());
 +                    }
 +                }
++            }
++
++            // Due 1.19.3 packet changes when apply the values we should resync it to local players.
++            for (ServerPlayer localPlayer : MinecraftServer.getServer().getPlayerList().localPlayers) {
++                entity.getEntityData().refresh(localPlayer);
 +            }
 +
 +            if (entity instanceof ExternalPlayer) {

--- a/patches/server/0034-Sync-mob-navigation-when-handing-over-to-another-ser.patch
+++ b/patches/server/0034-Sync-mob-navigation-when-handing-over-to-another-ser.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Sync mob navigation when handing over to another server
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 97257b450e848f53fdb9b5b7affa57b03ea5f459..a6b23761a22e6ace0234948bcff5bc7054dab659 100644
+index 2f2d9bb31194618ef5bba39cd1cbe7c4919e82c5..7d95f3d67498aef2a043d88e75610ad80208fa26 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -33,7 +33,7 @@ public abstract class PathNavigation {
@@ -18,10 +18,10 @@ index 97257b450e848f53fdb9b5b7affa57b03ea5f459..a6b23761a22e6ace0234948bcff5bc70
      protected int lastStuckCheck;
      protected Vec3 lastStuckCheckPos = Vec3.ZERO;
 diff --git a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-index 3a82773e577316f0457e4a739ca5df59593f2ad8..cd1d3a5bf8953168d805692df8cb5955137fc1db 100644
+index cdf00c101749d1fa76f8854542c3fc99150f2733..0b84e7e65fcad90a463b4ae40b0ce0abe37de7ef 100644
 --- a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
 +++ b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-@@ -127,6 +127,14 @@ public class MultiPaperEntitiesHandler {
+@@ -128,6 +128,14 @@ public class MultiPaperEntitiesHandler {
                  // Leaving our jurisdiction, do a full entity update to ensure the new external server has all the required info
                  if (!(entity instanceof ServerPlayer)) { // Ignore players as they aren't ticked by the new external server
                      MultiPaper.runSync(() -> MultiPaper.broadcastPacketToExternalServers(chunkTo.getChunkHolder().externalEntitiesSubscribers, () -> new EntityUpdateNBTPacket(entity)));

--- a/patches/server/0053-Close-minecart-containers-if-they-change-to-another-.patch
+++ b/patches/server/0053-Close-minecart-containers-if-they-change-to-another-.patch
@@ -19,10 +19,10 @@ index f402e2a2a9010d2cfc376ab347106f5924bccee3..55f64cbee76a962c843a3776d2913830
              broadcastPacketToExternalServers(newChunkHolder.externalSubscribers, () -> new SendTickListPacket(levelChunk));
              for (BlockEntity blockEntity : levelChunk.getBlockEntities().values()) {
 diff --git a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-index cd1d3a5bf8953168d805692df8cb5955137fc1db..c9b54786a716be52b5c4d83c2970e6ea860a7af1 100644
+index 0b84e7e65fcad90a463b4ae40b0ce0abe37de7ef..b53ee9310d25bf1dedf076ca8ab4a5c6789fc298 100644
 --- a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
 +++ b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-@@ -9,6 +9,7 @@ import net.minecraft.network.syncher.SynchedEntityData;
+@@ -10,6 +10,7 @@ import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkMap;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
@@ -30,7 +30,7 @@ index cd1d3a5bf8953168d805692df8cb5955137fc1db..c9b54786a716be52b5c4d83c2970e6ea
  import net.minecraft.world.entity.*;
  import net.minecraft.world.entity.ai.attributes.AttributeInstance;
  import net.minecraft.world.entity.ai.attributes.AttributeModifier;
-@@ -25,6 +26,7 @@ import net.minecraft.world.phys.Vec3;
+@@ -26,6 +27,7 @@ import net.minecraft.world.phys.Vec3;
  import org.apache.commons.lang.ArrayUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
@@ -38,7 +38,7 @@ index cd1d3a5bf8953168d805692df8cb5955137fc1db..c9b54786a716be52b5c4d83c2970e6ea
  import puregero.multipaper.config.MultiPaperConfiguration;
  import puregero.multipaper.externalserverprotocol.*;
  import puregero.multipaper.mastermessagingprotocol.messages.masterbound.UnsubscribeEntitiesMessage;
-@@ -126,6 +128,7 @@ public class MultiPaperEntitiesHandler {
+@@ -127,6 +129,7 @@ public class MultiPaperEntitiesHandler {
              if (!MultiPaper.isChunkLocal(chunkTo)) {
                  // Leaving our jurisdiction, do a full entity update to ensure the new external server has all the required info
                  if (!(entity instanceof ServerPlayer)) { // Ignore players as they aren't ticked by the new external server
@@ -46,7 +46,7 @@ index cd1d3a5bf8953168d805692df8cb5955137fc1db..c9b54786a716be52b5c4d83c2970e6ea
                      MultiPaper.runSync(() -> MultiPaper.broadcastPacketToExternalServers(chunkTo.getChunkHolder().externalEntitiesSubscribers, () -> new EntityUpdateNBTPacket(entity)));
                      if (entity instanceof Mob mob) {
                          MultiPaper.runSync(() -> {
-@@ -164,6 +167,15 @@ public class MultiPaperEntitiesHandler {
+@@ -165,6 +168,15 @@ public class MultiPaperEntitiesHandler {
          }
      }
  

--- a/patches/server/0101-Add-option-to-reduce-tracking-of-inactive-entities.patch
+++ b/patches/server/0101-Add-option-to-reduce-tracking-of-inactive-entities.patch
@@ -125,10 +125,10 @@ index 93a4c87dde7cd79b3a6cafd2a24550e9b31afea9..4e0992664fa8112bf3f09d48e4a60d8c
      public int remainingFireTicks;
      public boolean wasTouchingWater;
 diff --git a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-index c9b54786a716be52b5c4d83c2970e6ea860a7af1..8b95ed4a7bc93b0c12b19ad2eeec34c025ab07d4 100644
+index b53ee9310d25bf1dedf076ca8ab4a5c6789fc298..4a7ce8097a479d474dab78f230987bc563c73e69 100644
 --- a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
 +++ b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
-@@ -186,6 +186,10 @@ public class MultiPaperEntitiesHandler {
+@@ -187,6 +187,10 @@ public class MultiPaperEntitiesHandler {
      }
  
      public static void handleEntityUpdate(ExternalServerConnection connection, Entity entity, Packet<?> packet) {


### PR DESCRIPTION
* this should fix entities meta data not being synced to clients

closes #316

(server was not sending the updated metadata)