### PR TITLE
disable minecraft profiler in multipaper chunk handler, pass null as second parameter in DamageSourceSerializer case "badRespawnPoint"

### DIFF
--- a/patches/server/0138-fixup-Hurt-external-entities.patch
+++ b/patches/server/0138-fixup-Hurt-external-entities.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Wed, 8 Feb 2023 23:38:47 +0400
+Subject: [PATCH] fixup! Hurt external entities
+
+
+diff --git a/src/main/java/puregero/multipaper/util/DamageSourceSerializer.java b/src/main/java/puregero/multipaper/util/DamageSourceSerializer.java
+index b4d194d70cceacd9ef795ece2a40bdc00a403258..e47a8737bb897d91cbd1850545f126448ae8bb44 100644
+--- a/src/main/java/puregero/multipaper/util/DamageSourceSerializer.java
++++ b/src/main/java/puregero/multipaper/util/DamageSourceSerializer.java
+@@ -172,7 +172,7 @@ public class DamageSourceSerializer {
+             case "indirectMagic" -> DamageSource.indirectMagic(entities[0], entities[1]);
+ //            case "mob" -> DamageSource.indirectMobAttack(entities[0], (LivingEntity) entities[1]); // Handled above
+             case "player" -> DamageSource.playerAttack((Player) entities[0]);
+-            case "badRespawnPoint" -> DamageSource.badRespawnPointExplosion(sourcePosition);
++            case "badRespawnPoint" -> DamageSource.badRespawnPointExplosion(sourcePosition, null);
+             case "fireball" -> DamageSource.fireball((Fireball) entities[0], entities[1]);
+             case "sonic_boom" -> DamageSource.sonicBoom(entities[0]);
+             default -> throw new IOException("Unknown damage cause msgId of " + msgId);

--- a/patches/server/0139-Disable-Mojang-s-profile-call-in-MultiPaperChunkHand.patch
+++ b/patches/server/0139-Disable-Mojang-s-profile-call-in-MultiPaperChunkHand.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Wed, 8 Feb 2023 23:39:18 +0400
+Subject: [PATCH] Disable Mojang's profile call in MultiPaperChunkHandler
+
+
+diff --git a/src/main/java/puregero/multipaper/MultiPaperChunkHandler.java b/src/main/java/puregero/multipaper/MultiPaperChunkHandler.java
+index 09e4266bbdc06450ca72108dd2db357bc1e192b2..301b6c9daa3da6091b9f27ae36af815788dbd61b 100644
+--- a/src/main/java/puregero/multipaper/MultiPaperChunkHandler.java
++++ b/src/main/java/puregero/multipaper/MultiPaperChunkHandler.java
+@@ -218,9 +218,9 @@ public class MultiPaperChunkHandler {
+         holder.vanillaChunkHolder.blockChanged(pos);
+ 
+         if (oldState != null && blockState != oldState && (blockState.getLightBlock(chunk, pos) != oldState.getLightBlock(chunk, pos) || blockState.getLightEmission() != oldState.getLightEmission() || blockState.useShapeForLightOcclusion() || oldState.useShapeForLightOcclusion())) {
+-            chunk.level.getProfiler().push("queueCheckLightExternalUpdate");
++            //chunk.level.getProfiler().push("queueCheckLightExternalUpdate");
+             chunk.level.getChunkSource().getLightEngine().checkBlock(pos);
+-            chunk.level.getProfiler().pop();
++            //chunk.level.getProfiler().pop();
+         }
+     }
+ 


### PR DESCRIPTION
* Since Paper has deprecated the original method where you just pass single parameter