### PR TITLE
Fake Entity API

### DIFF
--- a/patches/api/0009-add-fake-entity-api.patch
+++ b/patches/api/0009-add-fake-entity-api.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Sun, 19 Feb 2023 13:53:24 +0400
+Subject: [PATCH] add fake entity api
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 12a69ecf648e0bdf3417b7ed04671156f2947add..626aa963059a4fced39f905c8f6b8124c6331e3d 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -1045,4 +1045,20 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+      */
+     void setImmuneToFire(@Nullable Boolean fireImmune);
+     // Purpur end
++    // MultiPaper start - add fake entity api
++    /**
++     * Sets the entity as fake entity
++     * <p>
++     * once set external players can't interact or see this entity.
++     * <p>
++     * Warning: once set this can't be changed.
++     *
++     * @throws IllegalStateException when online player is passed
++     */
++    void setFake();
++    /**
++     * returns whatever the entity is a fake entity
++     */
++    boolean isFake();
++    // MultiPaper end
+ }

--- a/patches/server/0020-Sync-player-files.patch
+++ b/patches/server/0020-Sync-player-files.patch
@@ -81,7 +81,7 @@ index bffef41525c10a5df581dfa390baef8a07e0c5cb..0902b98c9c1a2d2f9719c309fcfcf9a1
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/stats/ServerStatsCounter.java b/src/main/java/net/minecraft/stats/ServerStatsCounter.java
-index 72946e324c575ef39f3939225b96b68f724da460..4fc612e876db815f5e2a8477595c5d564f0b009e 100644
+index 72946e324c575ef39f3939225b96b68f724da460..e3aec9e92ce819305de2b1c10f45e66c926835ba 100644
 --- a/src/main/java/net/minecraft/stats/ServerStatsCounter.java
 +++ b/src/main/java/net/minecraft/stats/ServerStatsCounter.java
 @@ -17,12 +17,9 @@ import it.unimi.dsi.fastutil.objects.ObjectIterator;
@@ -108,43 +108,61 @@ index 72946e324c575ef39f3939225b96b68f724da460..4fc612e876db815f5e2a8477595c5d56
  
  public class ServerStatsCounter extends StatsCounter {
  
-@@ -54,6 +53,22 @@ public class ServerStatsCounter extends StatsCounter {
+@@ -54,8 +53,23 @@ public class ServerStatsCounter extends StatsCounter {
              Stat<ResourceLocation> wrapper = Stats.CUSTOM.get( entry.getKey() );
              this.stats.put( wrapper, entry.getValue().intValue() );
          }
 +        // MultiPaper start
-+        if (true) {
-+            try {
-+                String json = ExternalPlayer.loadedStats.remove(UUID.fromString(this.file.getName().split("\\.")[0]));
-+                if (json == null) json = MultiPaper.readStats(server.storageSource.levelDirectory.path().getFileName().toString(), this.file.getName().split("\\.")[0]);
-+                if (!json.isEmpty()) {
-+                    this.parseLocal(server.getFixerUpper(), json);
-+                }
++        try {
++            String json = ExternalPlayer.loadedStats.remove(UUID.fromString(this.file.getName().split("\\.")[0]));
++            if (json == null) json = MultiPaper.readStats(server.storageSource.levelDirectory.path().getFileName().toString(), this.file.getName().split("\\.")[0]);
++            if (!json.isEmpty()) {
++                this.parseLocal(server.getFixerUpper(), json);
++            }
 +            //} catch (IOException ioexception) {
 +            //    ServerStatsCounter.LOGGER.error("Couldn't read statistics file {}", file, ioexception);
-+            } catch (JsonParseException jsonparseexception) {
++        } catch (IllegalArgumentException e) {
++            LOGGER.warn("Invalid UUID was passed, possible a plugin doing weird stuff?, you can safely ignore this if you are using such plugins: {}", e.getMessage());
++        } catch (JsonParseException jsonparseexception) {
 +                ServerStatsCounter.LOGGER.error("Couldn't parse statistics file {}", file, jsonparseexception);
-+            }
-+            return;
 +        }
-+        // MultiPaper end
++
          // Spigot end
-         if (file.isFile()) {
+-        if (file.isFile()) {
++        /*if (file.isFile()) {
              try {
-@@ -70,6 +85,12 @@ public class ServerStatsCounter extends StatsCounter {
+                 this.parseLocal(server.getFixerUpper(), FileUtils.readFileToString(file));
+             } catch (IOException ioexception) {
+@@ -63,18 +77,21 @@ public class ServerStatsCounter extends StatsCounter {
+             } catch (JsonParseException jsonparseexception) {
+                 ServerStatsCounter.LOGGER.error("Couldn't parse statistics file {}", file, jsonparseexception);
+             }
+-        }
++        }*/
++        // MultiPaper end
+ 
+     }
+ 
      public void save() {
          if ( org.spigotmc.SpigotConfig.disableStatSaving ) return; // Spigot
-         try {
-+            // MultiPaper start
-+            if (true) {
-+                MultiPaper.writeStats(server.storageSource.levelDirectory.path().getFileName().toString(), this.file.getName().split("\\.")[0], this.toJson());
-+                return;
-+            }
-+            // MultiPaper end
-             FileUtils.writeStringToFile(this.file, this.toJson());
-         } catch (IOException ioexception) {
-             ServerStatsCounter.LOGGER.error("Couldn't save stats", ioexception);
-@@ -202,7 +223,7 @@ public class ServerStatsCounter extends StatsCounter {
+-        try {
+-            FileUtils.writeStringToFile(this.file, this.toJson());
+-        } catch (IOException ioexception) {
+-            ServerStatsCounter.LOGGER.error("Couldn't save stats", ioexception);
+-        }
+-
++        // MultiPaper start
++        //try {
++        MultiPaper.writeStats(server.storageSource.levelDirectory.path().getFileName().toString(), this.file.getName().split("\\.")[0], this.toJson());
++            //FileUtils.writeStringToFile(this.file, this.toJson());
++        // } catch (Exception ioexception) {
++        //    ServerStatsCounter.LOGGER.error("Couldn't save stats", ioexception);
++        // }
++        // MultiPaper end
+     }
+ 
+     @Override
+@@ -202,7 +219,7 @@ public class ServerStatsCounter extends StatsCounter {
          return nbttagcompound;
      }
  

--- a/patches/server/0027-Sync-entities.patch
+++ b/patches/server/0027-Sync-entities.patch
@@ -305,7 +305,7 @@ index 9da2d2c0eaad120d35f68a18df16ef99fc494d94..e793a3fab3077393e19c541ef966beab
              return this.entityLookup.addNewEntity(entity); // Paper - rewrite chunk system
          }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index af0a4aa60d42464b95a5aa7819dc74a4a5bd28fe..fd61c88755fd4f100bf60126e277eff9ffb6d601 100644
+index 4161bbb46cce9d82ef28020aff64d5c083c83f92..8249a477861c2767dbbaf2a71adf9b59761fd55b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1381,7 +1381,7 @@ public class ServerPlayer extends Player {
@@ -539,7 +539,7 @@ index 43cc8e8f07adecef21c70954918b8945a7c3ef62..69757ecbf3aa463d7b25902dfe500e0e
              if (this.leashInfoTag.hasUUID("UUID")) {
                  UUID uuid = this.leashInfoTag.getUUID("UUID");
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index a23d3aec7cec9114b8f7a2f26d72153a90c5a5a4..70556bd631869a317ddfc76448729632687f16e7 100644
+index 0c632cd0cb932a4cfaf2288c9d109325d5287537..f861e5c2c6238908f63165aac289fd2cea621deb 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -144,7 +144,7 @@ public abstract class Player extends LivingEntity {
@@ -552,7 +552,7 @@ index a23d3aec7cec9114b8f7a2f26d72153a90c5a5a4..70556bd631869a317ddfc76448729632
      protected static final EntityDataAccessor<CompoundTag> DATA_SHOULDER_RIGHT = SynchedEntityData.defineId(Player.class, EntityDataSerializers.COMPOUND_TAG);
      private long timeEntitySatOnShoulder;
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index 7f3a7a769afec8449547c26453112064b9bcb04a..6d023c5148e760ac0c8ff887257ff8ff8fa19868 100644
+index 15fb5ee374b19366ebb23181896fb943e95819f0..03e86894a4440bbb7a368267724626c9dbee3a21 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -49,6 +49,7 @@ import org.slf4j.Logger;
@@ -2065,13 +2065,14 @@ index 0000000000000000000000000000000000000000..26df6c6d6052f71da435d4ef973d1bb1
 +}
 diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..893ae068f0d08efad14c3a9b1a731a939cd26133
+index 0000000000000000000000000000000000000000..1566c1af1db1c2c727ded98d266920dbf7236bd5
 --- /dev/null
 +++ b/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,90 @@
 +package puregero.multipaper.externalserverprotocol;
 +
 +import net.minecraft.network.FriendlyByteBuf;
++import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ServerLevel;
 +import net.minecraft.server.level.ServerPlayer;
 +import net.minecraft.world.entity.Entity;
@@ -2144,10 +2145,10 @@ index 0000000000000000000000000000000000000000..893ae068f0d08efad14c3a9b1a731a93
 +    }
 +
 +    private void triedToRequestPlayer(ExternalServerConnection connection, ServerPlayer serverPlayer) {
++        if (!MinecraftServer.getServer().getPlayerList().players.contains(serverPlayer)) return;
 +        Pair<UUID, ExternalServerConnection> key = Pair.of(serverPlayer.getUUID(), connection);
 +        int count = playerRequestCounts.getOrDefault(key, 0);
 +        playerRequestCounts.put(key, count + 1);
-+
 +        if (count > 10) {
 +            LOGGER.error(connection.externalServer.getName() + " tried to request player " + serverPlayer.getScoreboardName() + " more than 10 times! This means they didn't sync correctly. Kicking them.");
 +            serverPlayer.getBukkitEntity().kickPlayer("Your player failed to sync. Please reconnect.");

--- a/patches/server/0140-add-fake-entity-api.patch
+++ b/patches/server/0140-add-fake-entity-api.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mohammed jasem alaajel <xrambad@gmail.com>
+Date: Sun, 19 Feb 2023 16:10:33 +0400
+Subject: [PATCH] add fake entity api
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 4f8e2791ed45ddca5fec77d24e52b490146e2a2e..7a2c1178caa4c68e004746f05c67ad029d9ad9d2 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -59,6 +59,7 @@ import net.minecraft.network.protocol.game.VecDeltaCodec;
+ import net.minecraft.network.syncher.EntityDataAccessor;
+ import net.minecraft.network.syncher.EntityDataSerializers;
+ import net.minecraft.network.syncher.SynchedEntityData;
++import net.minecraft.obfuscate.DontObfuscate;
+ import net.minecraft.resources.ResourceKey;
+ import net.minecraft.resources.ResourceLocation;
+ import io.papermc.paper.util.MCUtil;
+@@ -411,7 +412,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+     public boolean freezeLocked = false; // Paper - Freeze Tick Lock API
+     public boolean collidingWithWorldBorder; // Paper
+     public @Nullable Boolean immuneToFire = null; // Purpur - Fire immune API
+-
++    public volatile boolean fake = false; // MultiPaper - Fake entity nms
+     public void setOrigin(@javax.annotation.Nonnull Location location) {
+         this.origin = location.toVector();
+         this.originWorld = location.getWorld().getUID();
+@@ -4904,4 +4905,19 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+         return false;
+     }
+     // Purpur end
++    // MultiPaper start - Fake entity nms
++    @DontObfuscate
++    public boolean isFake() {
++        return this.fake;
++    }
++
++    @DontObfuscate
++    public void setFake() {
++        // we need to make sure that actual players are not set fake
++        if (this instanceof ServerPlayer serverPlayer && getServer().getPlayerList().players.contains(serverPlayer)) {
++            throw new IllegalStateException("Online player cannot be set as fake entity");
++        }
++        this.fake = true;
++    }
++    // MultiPaper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 68abc441d8b3ffebe6ac2475899cf32b445c3d73..f7b950e0d71bc545721ad417d1e7611eb9403977 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -1470,4 +1470,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         getHandle().immuneToFire = fireImmune;
+     }
+     // Purpur end
++    // MultiPaper start - add fake entity api
++    @Override
++    public void setFake() {
++        this.getHandle().setFake();
++    }
++
++    @Override
++    public boolean isFake() {
++        return this.getHandle().isFake();
++    }
++    // MultiPaper stop
+ }
+diff --git a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
+index 4a7ce8097a479d474dab78f230987bc563c73e69..68103e725cd9b23ffcc51e7b70fa040ab705c4ed 100644
+--- a/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
++++ b/src/main/java/puregero/multipaper/MultiPaperEntitiesHandler.java
+@@ -335,7 +335,7 @@ public class MultiPaperEntitiesHandler {
+     }
+ 
+     public static boolean shouldSyncEntity(Entity entity) {
+-        return entity.shouldBeSaved() || entity instanceof LightningBolt || entity instanceof LeashFenceKnotEntity;
++        return !entity.isFake() && (entity.shouldBeSaved() || entity instanceof LightningBolt || entity instanceof LeashFenceKnotEntity);
+     }
+ 
+     public static void onEntityRemove(Entity entity, Entity.RemovalReason reason) {
+diff --git a/src/main/java/puregero/multipaper/MultiPaperEntityInteractHandler.java b/src/main/java/puregero/multipaper/MultiPaperEntityInteractHandler.java
+index 6b212628a7c4e4bc9d3458fc7a79d88bbf866c47..54126110ba25f6ac16bfe55b19c0e39d3217da3b 100644
+--- a/src/main/java/puregero/multipaper/MultiPaperEntityInteractHandler.java
++++ b/src/main/java/puregero/multipaper/MultiPaperEntityInteractHandler.java
+@@ -17,6 +17,7 @@ public class MultiPaperEntityInteractHandler {
+     private static final Logger LOGGER = LogManager.getLogger(MultiPaperEntityInteractHandler.class.getSimpleName());
+ 
+     public static ExternalServerConnection getOwner(Entity entity) {
++        if (entity.isFake()) return null;
+         NewChunkHolder newChunkHolder = MultiPaper.getChunkHolder(entity);
+ 
+         if (MultiPaperEntitiesHandler.getControllingPassenger(entity) instanceof ExternalPlayer externalPlayer) {
+@@ -29,6 +30,7 @@ public class MultiPaperEntityInteractHandler {
+     }
+ 
+     public static boolean handleEntityInteract(ServerPlayer player, Entity entity, ServerboundInteractPacket packet) {
++        if (entity.isFake()) return false;
+         ExternalServerConnection owner = getOwner(entity);
+         if (owner != null) {
+             owner.send(new PlayerActionOnEntityPacket(player, entity, packet));
+@@ -40,7 +42,7 @@ public class MultiPaperEntityInteractHandler {
+ 
+     public static boolean touchEntity(Player player, Entity entity) {
+         NewChunkHolder newChunkHolder = MultiPaper.getChunkHolder(entity);
+-
++        if (entity.isFake()) return false;
+         if (MultiPaper.isRealPlayer(entity)) {
+             return false;
+         } else if (MultiPaper.isChunkExternal(newChunkHolder) && !(entity instanceof FishingHook)) {
+diff --git a/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java b/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java
+index 1566c1af1db1c2c727ded98d266920dbf7236bd5..79e06c335a29769d83cdc73bf2426675382b1808 100644
+--- a/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java
++++ b/src/main/java/puregero/multipaper/externalserverprotocol/RequestEntityPacket.java
+@@ -54,6 +54,7 @@ public class RequestEntityPacket extends ExternalServerPacket {
+             Entity entity = level.getEntity(uuid);
+             Visibility visibility = level.getEntityLookup().getEntityStatusByUUID(uuid);
+             if (entity != null && visibility != null && visibility.isAccessible()) {
++                if (entity.isFake()) return;
+                 if (entity instanceof ServerPlayer serverPlayer) {
+                     triedToRequestPlayer(connection, serverPlayer);
+                     return;


### PR DESCRIPTION
This Pull request aims to solve problems of NPCs plugins that uses `NMS`  with MultiPaper syncing system.

some would argue plugins uses unsupported part of the server, but i would say this rather Server <----> Server protocol limitation

## New API
as server has no way to differentiate what entity to sync or not  this api has been added.

* Added `Entity#setFake()` to set entity as fake in `Bukkit api` and it also exists in nms class 
* Added `Entity#isFake()` to get status if not fake or not in`Bukkit api` and it also exists in nms class 
* Javadocs for the api has been added

setting entity as fake prevent its from being synced in `Server < -- > Server` protocol but excluding movements if entity exists with same uuid

so as result plugins needed to be modified and call method `Entity#setFake()`, but its not required but recommended to do it.

https://github.com/ham1255/Citizens2 is an example for that which is modified version


## fixes:
* warn the user instead of throwing error in Stats counter of player in-case of invalid UUID

```
[16:22:48 INFO]: HKM_ALS issued server command: /npc create ham1255
[16:22:48 WARN]: Invalid UUID was passed, possible a plugin doing weird stuff?, you can safely ignore this if you are using such plugins: Invalid UUID string: Citizens
[16:22:50 WARN]: Invalid UUID was passed, possible a plugin doing weird stuff?, you can safely ignore this if you are using such plugins: Invalid UUID string: Citizens

```
# closes
#354 #325 and closes Pull request #319

 
