### PR TITLE
Root project config chanages

### DIFF
--- a/MultiPaper-Master/build.gradle.kts
+++ b/MultiPaper-Master/build.gradle.kts
@@ -1,7 +1,7 @@
-version = "2.11.0"
+version = "${properties["masterVersion"]}"
 
 plugins {
-    `java`
+    java
     `maven-publish`
     id("com.github.johnrengelman.shadow")
 }
@@ -30,7 +30,9 @@ dependencies {
 tasks.jar {
     manifest {
         attributes(
-                "Main-Class" to "puregero.multipaper.server.MultiPaperServer"
+            "Main-Class" to "puregero.multipaper.server.MultiPaperServer",
+            "Minecraft-Version" to "${properties["mcVersion"]}",
+            "Master-Version" to "${properties["masterVersion"]}"
         )
     }
 }

--- a/MultiPaper-MasterMessagingProtocol/build.gradle.kts
+++ b/MultiPaper-MasterMessagingProtocol/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
-    `java`
+    java
+    `maven-publish`
 }
+
+version = "${properties["masterVersion"]}-${properties["mcVersion"]}"
 
 repositories {
     maven {
@@ -11,3 +14,10 @@ repositories {
 dependencies {
     compileOnly("io.netty:netty-all:4.1.75.Final")
 }
+
+publishing {
+    publications.create<MavenPublication>("maven") {
+        artifact(tasks.jar)
+    }
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import io.papermc.paperweight.util.constants.*
 
 plugins {
     java
+    `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("io.papermc.paperweight.patcher") version "1.5.1"
 }
@@ -104,6 +105,25 @@ paperweight {
                 from(tempDir.file("gradle.properties"))
                 into(project.file(file).parent)
             }
+        }
+    }
+}
+
+tasks.generateDevelopmentBundle {
+    apiCoordinates.set("puregero.multipaper:MultiPaper-API")
+    mojangApiCoordinates.set("io.papermc.paper:paper-mojangapi")
+    libraryRepositories.set(
+        listOf(
+            "https://repo.maven.apache.org/maven2/",
+            "https://repo.papermc.io/repository/maven-public/",
+            "https://jitpack.io"
+        )
+    )
+}
+publishing {
+    publications.create<MavenPublication>("devBundle") {
+        artifact(tasks.generateDevelopmentBundle) {
+            artifactId = "dev-bundle"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ mcVersion = 1.19.3
 
 purpurRef = 9940dcf74be5d871c452590943b4e269b3f3b666
 
+masterVersion = 2.11.0
+
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=false


### PR DESCRIPTION
* Ability to generate `Dev Bundle` see Paperweight userdev plugin
* Master version has been moved to the gradle props file
* Master messging protocol can be published with versioning like this `Master version-Minecraft version ` like this `2.11.0-1.19.3`
* include minecraft version / master version into the master manifest 