### PR TITLE
Fix ability to duplicate items enchanted in anvils

### DIFF
--- a/patches/server/0141-Fix-ability-to-duplicate-items-enchanted-in-anvils.patch
+++ b/patches/server/0141-Fix-ability-to-duplicate-items-enchanted-in-anvils.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stuart Pomeroy <stuart@pomeroys.site>
+Date: Sun, 26 Mar 2023 15:52:49 +0100
+Subject: [PATCH] Fix ability to duplicate items enchanted in anvils
+
+By default Paper makes a change that automatically sorts the enchantments on an item when enchanted or parsed from NBT. This change did not account for enchanting items through an Anvil.
+
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index 26a199f2008b5651cdf185883635f6af39815eaf..f7803e95aa1fea9cf01342294a097075953b5372 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -1227,6 +1227,7 @@ public final class ItemStack {
+     public void addTagElement(String key, Tag element) {
+         this.getOrCreateTag().put(key, element);
+ 
++        if(key.equals("Enchantments")) processEnchantOrder(this.getOrCreateTag()); // MultiPaper - Reorder enchantments to prevent desync.
+         markDirty(); // MultiPaper
+     }
+ 


### PR DESCRIPTION
This fixes https://github.com/MultiPaper/MultiPaper/issues/196

I've done some investigation into this and it appears this is caused by a bug from a Paper patch. The patch sorts the enchantments based on their ID when an item is enchanted through most means, however it seems like they missed out when an item is enchanted via an Anvil. When the item is sent to other servers to be synced, it gets passed through the ItemStack.of method which then sorts the enchantments, meaning that the Item on the server where it was originally enchanted is now out of sync with the server that the player is on due to the NBT tags not matching. This causes the duplication because as far as the server is aware, they are different items as the enchantments are in a different order.

It looks like there are some open issues and PR's in the Paper repository (https://github.com/PaperMC/Paper/pull/7335, https://github.com/PaperMC/Paper/issues/6437) related to this issue which haven't been solved / merged. I've written a quick patch (for 1.19.3 & 1.19.4) that would resolve this issue, however it is not ideal as it affects the order of enchantments which can be important when using an Anvil. It would be up to the maintainers as to if they wish to merge my patch.

Please let me know if you have any questions.