### PR TITLE
 Add handling of list config values with command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ java
   -Dproperties.view-distance=16
   -Dpaper.global.proxies.proxy-protocol=true
   -Dspigot.world-settings.default.entity-tracking-range.players=128
+  -Dmultipaper.sync-settings.filesToSyncOnStartup="myconfigfile.yml;plugins/MyPlugin.jar"
   -jar multipaper.jar
 ```
 

--- a/patches/server/0150-Add-handling-of-list-config-values-with-command-line.patch
+++ b/patches/server/0150-Add-handling-of-list-config-values-with-command-line.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ian Steiger <iksteiger@gmail.com>
+Date: Fri, 7 Jun 2024 02:03:24 +0000
+Subject: [PATCH] Add handling of list config values with command line options
+
+
+diff --git a/src/main/java/puregero/multipaper/config/MultiPaperConfigurationLoader.java b/src/main/java/puregero/multipaper/config/MultiPaperConfigurationLoader.java
+index f0ec43cb2051ee6c74856cf24c8d26bec1dd61a3..929149bb9762448c935fdfadbde0fb623aeb504e 100644
+--- a/src/main/java/puregero/multipaper/config/MultiPaperConfigurationLoader.java
++++ b/src/main/java/puregero/multipaper/config/MultiPaperConfigurationLoader.java
+@@ -69,7 +69,12 @@ public class MultiPaperConfigurationLoader {
+             if (property.getKey().toString().startsWith("multipaper.")) {
+                 String key = property.getKey().toString().substring("multipaper.".length());
+                 try {
+-                    node.node((Object[]) key.split("\\.")).set(property.getValue());
++                    String value = ((String) property.getValue());
++                    if(value.contains(";")) {
++                        node.node((Object[]) key.split("\\.")).set(value.split(";"));
++                    } else {
++                        node.node((Object[]) key.split("\\.")).set(value);
++                    }                
+                 } catch (SerializationException e) {
+                     e.printStackTrace();
+                 }


### PR DESCRIPTION
This adds the ability to configure list configuration options via command line properties:

Ex: `-Dmultipaper.sync-settings.filesToSyncOnStartup="myconfigfile.yml;plugins/MyPlugin.jar"`