### PR TITLE
Update to Paper version 1.21.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **MultiPaper is in public beta.** Most features work for most players most of
 the time, however things can occasionally break.
 
-1.20.1 [Purpur](https://github.com/PurpurMC/Purpur) fork that enables a server admin
+1.21.3 [Purpur](https://github.com/PurpurMC/Purpur) fork that enables a server admin
 to scale a single world across multiple servers. Multiple MultiPaper servers run
 the same world and use a MultiPaper-Master to coordinate with each other and
 store server data. While the MultiPaper-Master is usually run as a standalone
@@ -181,7 +181,7 @@ repositories {
 }
 
 dependencies {
-  compile "com.github.puregero:multipaper-api:1.20.1-R0.1-SNAPSHOT"
+  compile "com.github.puregero:multipaper-api:1.21.3-R0.1-SNAPSHOT"
 }
 ```
 
@@ -198,7 +198,7 @@ Or in your pom.xml:
     <dependency>
         <groupId>com.github.puregero</groupId>
         <artifactId>multipaper-api</artifactId>
-        <version>1.20.1-R0.1-SNAPSHOT</version>
+        <version>1.21.3-R0.1-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,7 @@ paperweight {
             )
 
             val purpurLatestCommitJson = layout.cache.resolve("purpurLatestCommit.json");
-            download.get().download("https://api.github.com/repos/PurpurMC/Purpur/commits/ver/1.20.1", purpurLatestCommitJson);
+            download.get().download("https://api.github.com/repos/PurpurMC/Purpur/commits/ver/1.21.3", purpurLatestCommitJson);
             val purpurLatestCommit = gson.fromJson<paper.libs.com.google.gson.JsonObject>(purpurLatestCommitJson)["sha"].asString;
 
             copy {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 group = puregero.multipaper
-version = 1.20.1-R0.1-SNAPSHOT
-mcVersion = 1.20.1
+version = 1.21.3-R0.1-SNAPSHOT
+mcVersion = 1.21.3
 
-purpurRef = f6fd5f6ba6e672bfdbc79def7e8598d984ec8b3c
+purpurRef = 03062a856ed0c3603e2e8b69ebd0b36c8a6942d1
 
-masterVersion = 2.12.3
+masterVersion = 2.12.4
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Updates the Paper/Minecraft version up to `1.21.3` from the previous version `1.20.1`. Additionally, this also bumps the version of the master.